### PR TITLE
fix: #27 - 데이터 모델 항목 변경

### DIFF
--- a/Look-out-the-window/Look-out-the-window/Data/DTO/DailyWeatherDTO.swift
+++ b/Look-out-the-window/Look-out-the-window/Data/DTO/DailyWeatherDTO.swift
@@ -84,7 +84,8 @@ extension DailyWeatherDTO {
     }
     
     func toDailyModel() -> DailyModel {
-        return DailyModel(day: self.currentTime.convertUnixTimeToWeekString(),
+        return DailyModel(unixTime: self.currentTime,
+                          day: self.currentTime.convertUnixTimeToWeekString(),
                           high: String(self.temperature.maxTemperature),
                           low: String(self.temperature.minTemperature),
                           weatherInfo: self.toWeatherImageString())

--- a/Look-out-the-window/Look-out-the-window/Data/DTO/HourlyWeatherDTO.swift
+++ b/Look-out-the-window/Look-out-the-window/Data/DTO/HourlyWeatherDTO.swift
@@ -83,7 +83,7 @@ extension HourlyWeatherDTO {
     }
     
     func toHourlyModel() -> HourlyModel {
-        return HourlyModel(hour: self.currentTime.convertUnixTimeToHourString(),
+        return HourlyModel(hour: self.currentTime,
                            temperature: String(self.temperature),
                            weatherInfo: self.toWeatherImageString())
     }

--- a/Look-out-the-window/Look-out-the-window/Data/DTO/WeatherResponseDTO.swift
+++ b/Look-out-the-window/Look-out-the-window/Data/DTO/WeatherResponseDTO.swift
@@ -176,6 +176,8 @@ extension WeatherResponseDTO {
     func toCurrentWeather() -> CurrentWeather {
         return CurrentWeather(
             address: nil,
+            lat: lat,
+            lng: lng,
             currentTime: self.currentWeather.currentTime + self.timeZoneOffset - 32400,
             currentMomentValue: toMomentValue(),
             sunriseTime: self.currentWeather.sunriseTime + self.timeZoneOffset - 32400,

--- a/Look-out-the-window/Look-out-the-window/Data/Model/CurrentWeather.swift
+++ b/Look-out-the-window/Look-out-the-window/Data/Model/CurrentWeather.swift
@@ -12,6 +12,10 @@ import Foundation
 struct CurrentWeather {
     /// 위치 또는 주소 정보 (예: "서울특별시 강남구")
     let address: String?
+    /// 요청된 위치의 위도
+    let lat: Double
+    /// 요청된 위치의 경도
+    let lng: Double
     /// 현재 시간 Unix
     let currentTime: Int
     /// 현재 순간(새벽, 아침, 낮, 오후, 밤) 기준 투명값 (0.0 ~ 0.5)

--- a/Look-out-the-window/Look-out-the-window/Presentation/Main/MainSectionDataModel.swift
+++ b/Look-out-the-window/Look-out-the-window/Presentation/Main/MainSectionDataModel.swift
@@ -25,6 +25,7 @@ struct HourlyModel {
 
 struct DailyModel {
     // 요일, 하늘상태(이미지 -> String), 최저 - 최고 온도
+    let unixTime: Int
     let day: String
     let high: String
     let low: String

--- a/Look-out-the-window/Look-out-the-window/Presentation/Main/MainSectionDataModel.swift
+++ b/Look-out-the-window/Look-out-the-window/Presentation/Main/MainSectionDataModel.swift
@@ -17,7 +17,7 @@ import RxDataSources
 
 // MARK: - 각 섹션 DataModel (수정 필요해 보임)
 struct HourlyModel {
-    let hour: String      // 포맷 수정  ( 12시간 -> Cell 12개 정도)
+    let hour: Int      // 포맷 수정  ( 12시간 -> Cell 12개 정도)
     let temperature: String  // 섭씨
     // weatherState
     let weatherInfo: String // Asset네이밍 변환받아 전달받을 예정


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #27 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 데이터 모델 항목 변경
- CurrentWeather 위도,경도 추가
- DailyModel에 unixTime 추가 이유: CoreData에서 불러오는 DailyModel은 NSSet타입으로 순서가 보장되지 않음
- 데이터를 사용할 때, 오늘, 내일, 모레 순으로 순서가 중요하므로 정렬기준을 잡기 위해 unixTime 항목 추가
- HoulyModel의 hour을 Integer타입으로 수정 , 이유는 위와 동일
- configure부분에서 `hour.convertUnixTimeToHourString`로 변환하여 사용

### 🔥 데이터 모델부분만 변경했습니다! 현재 작업중인 곳에서 호출된다면 수정이 필요합니다